### PR TITLE
feat(wechat): Adapted to WeChat version 8.0.43

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# 此脚本 在 8.0.39 的微信提取的数据中可正常使用 
+# 此脚本 在 8.0.43 的微信提取的数据中可正常使用 
 import json
 import sqlite3
 import os
@@ -23,7 +23,7 @@ magic_number = 8388607990
 #       |------------ var_payload
 
 # wxid_xxxx 标识位
-WXID_FLAG = b'\x18\x00\x2A'
+WXID_FLAG = b'\x18\x00\x20'
 # 朋友圈文字内容标识位
 CONTENT_FLAG = b'\xba\x01'
 # 朋友圈图片标识位
@@ -72,8 +72,15 @@ def load_moments(hash):
 # 根据 start 和 off 截取 hex 并解码为文字
 def decode_msg(hex_includes_msg, start, off):
     msg_hex = hex_includes_msg[start:start+off]
-    msg_str = msg_hex.decode()
-    return msg_str
+    if off == 0x00:
+        return ""
+    else:
+        try:
+            msg_str = msg_hex.decode()
+            return msg_str
+        except:
+            print("解密失败，请手动处理")
+            return "(解密失败，请手动处理)"
 
 # msg_payload 包含文字长度和文字内容本身，从 msg_payload 中获取实际 msg 的偏移量和长度
 def get_msg_off_and_len(hex_includes_msg):
@@ -241,6 +248,7 @@ def main(options=default_option):
             id = i[:-4]
             if len(wxId) == 0:
                 wxId = get_text_by_flag(hex, WXID_FLAG, first=True)
+            print(f"Parsing: {i}")
             moment = extract_moment(hex, id)
             moments.append(moment)
 


### PR DESCRIPTION
从 https://atlas.xlog.app/how-to-export-moments-and-post-on-chain 拜读而来

非常感谢作者大大的努力和编写的脚本工具，自三年大封控之后，我表达的欲望已经急剧降低。但不可否认的是，在过去十年的漫长时光里，微信朋友圈是我「分享生活」的主要途径，承载了我一部分的个人和集体记忆。

在过去的三年，我找了很久如何导出微信朋友圈的方法，但都已经不支持新的客户端了。直到我找到了您的文章和可供使用的程序，与目前的客户端版本号接近。根据我的使用环境，我对脚本进行了一些小幅更新

- 修改 WXID 标识位 (8.0.43版本标识位改变)
- 忽略解码错误（根本原因是HEX匹配时可能会出现重复导致偏移量有误，需要做异常处理）
- (Debug) 扫描文件时添加提示用于手动处理

修改后的程序在 iPadOS 17 测试通过，导出了从我开始使用微信（2013年）至今所有的朋友圈（共2047条），下载图片及略缩图 4327 张，需要手动修复8条朋友圈（1条正文内容，7条是分享标题）

再次对您表示感谢！